### PR TITLE
script: Make sure device is in bootloader fastboot and not fastbootd

### DIFF
--- a/Linux/flash_all.sh
+++ b/Linux/flash_all.sh
@@ -73,6 +73,10 @@ function CreateLogicalPartition {
     fi
 }
 
+function RebootToBootloaderFastboot {
+    $fastboot reboot bootloader
+}
+
 function ResizeLogicalPartition {
     for i in $logical_partitions; do
         for s in a b; do 
@@ -96,6 +100,9 @@ echo "#############################"
 echo "# CHECKING FASTBOOT DEVICES #"
 echo "#############################"
 $fastboot devices
+
+# Make sure device is in the bootloader fastboot mode and not fastbootd.
+RebootToBootloaderFastboot
 
 ACTIVE_SLOT=$($fastboot getvar current-slot 2>&1 | awk 'NR==1{print $2}')
 if [ ! $ACTIVE_SLOT = "waiting" ] && [ ! $ACTIVE_SLOT = "a" ]; then

--- a/Windows/flash_all.bat
+++ b/Windows/flash_all.bat
@@ -33,6 +33,8 @@ echo # CHECKING FASTBOOT DEVICES #
 echo #############################
 %fastboot% devices
 
+%fastboot% reboot bootloader
+
 %fastboot% getvar current-slot 2>&1 | find /c "current-slot: a" > tmpFile.txt
 set /p active_slot= < tmpFile.txt
 del /f /q tmpFile.txt


### PR DESCRIPTION
Fastbootd mode sometimes can't flash certain firmware partitions (such as dtbo). Make sure device is in the correct (bootloader-provided) fastboot mode before flashing.